### PR TITLE
OU-4129 Fix for problem with sci notation with 1 sig fig

### DIFF
--- a/questionbase.php
+++ b/questionbase.php
@@ -327,7 +327,10 @@ class qtype_varnumeric_question_base extends question_graded_automatically_with_
                 $no['coeff1'] =  substr($no['coeff2'], 0, 1);
                 $no['coeff2'] =  substr($no['coeff2'], 1);
             }
-            $string = $no['sign'].$no['coeff1'].'.'.$no['coeff2'].'e'.$no['exp'];
+            if ($no['coeff2'] !== '') {
+                $no['coeff2'] = '.'.$no['coeff2'];
+            }
+            $string = $no['sign'].$no['coeff1'].$no['coeff2'].'e'.$no['exp'];
         } else {
             if ($string === '-0') {//unlikely but possible
                 $string = '0';

--- a/simpletest/helper.php
+++ b/simpletest/helper.php
@@ -36,7 +36,8 @@ defined('MOODLE_INTERNAL') || die();
 class qtype_varnumericset_test_helper extends question_test_helper {
     public function get_test_questions() {
         return array('no_accepted_error', 'numeric_accepted_error', '3_sig_figs', '3_sig_figs_2',
-                        '3_sig_figs_trailing_zero', '3_sig_figs_trailing_zero_negative_answer');
+                        '3_sig_figs_trailing_zero', '3_sig_figs_trailing_zero_negative_answer',
+                        '1_sig_fig');
     }
 
     /**
@@ -142,4 +143,22 @@ class qtype_varnumericset_test_helper extends question_test_helper {
         $vs->answers[1]->sigfigs = 3;
         return $vs;
     }
+
+
+    /**
+     * @return qtype_varnumericset_question
+     */
+    public function make_varnumericset_question_1_sig_fig() {
+        $vs = $this->make_varnumericset_question_no_accepted_error();
+
+        $vs->questiontext = '<p>The correct answer is 1e9.</p>';
+        $vs->generalfeedback = '<p>General feedback 1e9.</p>';
+        $vs->requirescinotation = 1;
+        $vs->answers[1]->answer = '1.0e9';
+        $vs->answers[1]->sigfigs = 1;
+        $vs->answers[1]->checknumerical = 1;
+        $vs->answers[1]->checkscinotation = 1;
+        return $vs;
+    }
+
 }

--- a/simpletest/testquestion.php
+++ b/simpletest/testquestion.php
@@ -119,6 +119,9 @@ class qtype_varnumericset_question_test extends UnitTestCase {
             qtype_varnumericset_question::has_number_of_sig_figs('151000', 3));
         $this->assertFalse(
             qtype_varnumericset_question::has_number_of_sig_figs('152000', 2));
+        $this->assertTrue(
+            qtype_varnumericset_question::has_number_of_sig_figs('1e9', 1));
+
     }
     public function test_has_too_many_sig_figs() {
         $this->assertTrue(qtype_varnumericset_question::has_too_many_sig_figs('1.23456e5', 123456, 2));;
@@ -241,6 +244,15 @@ class qtype_varnumericset_question_test extends UnitTestCase {
         $this->assertEqual($this->grade($question, '-00.07200'), 90);
         $this->assertEqual($this->grade($question, '-00.07200'), 90);
         $this->assertEqual($this->grade($question, '-0.072'), 0);
+
+        $question = test_question_maker::make_question('varnumericset', '1_sig_fig');
+        $this->assertEqual($this->grade($question, '1e9'), 100);
+        $this->assertEqual($this->grade($question, '1x10<sup>9</sup>'), 100);
+        $this->assertEqual($this->grade($question, '+1x10<sup>+9</sup>'), 100);
+        $question->answers[1]->answer = '-1.0e9';
+        $this->assertEqual($this->grade($question, '-1e9'), 100);
+        $this->assertEqual($this->grade($question, '-1x10<sup>9</sup>'), 100);
+        $this->assertEqual($this->grade($question, '-1x10<sup>+9</sup>'), 100);
     }
 
     public function test_normalize_number_format() {


### PR DESCRIPTION
Fix for http://ltsredmine.open.ac.uk/issues/4129

Difference in behavious of variable numeric and variable numeric sets when non-numeric entered.

With unit tests.
