### PR TITLE
align answer fields with 'give feedback...'

### DIFF
--- a/edit_varnumericset_form_base.php
+++ b/edit_varnumericset_form_base.php
@@ -195,24 +195,29 @@ abstract class qtype_varnumeric_edit_form_base extends question_edit_form {
         $repeated[] = $mform->createElement('static', 'autofirehdr', '',
                                                  get_string('autofirehdr', 'qtype_varnumericset', ''));
         $autofirerow1 = array();
-        $autofirerow1[] = $mform->createElement('selectyesno', 'checknumerical', '');
+        $autofirerow1[] = $mform->createElement('selectyesno', 'checknumerical',
+                                                 get_string('checknumerical',  'qtype_varnumericset'));
         $checkpowerof10options = array(0 => get_string('no'),
                                        1 => '+/- 1', 2 => '+/- 2', 3 => '+/- 3',
                                        4 => '+/- 4', 5 => '+/- 5', 6 => '+/- 6');
         $autofirerow1[] = $mform->createElement('selectyesno', 'checkscinotation',
                                                  get_string('checkscinotation', 'qtype_varnumericset'));
-        $repeated[] = $mform->createElement('group', 'autofirerow1', get_string('checknumerical',  'qtype_varnumericset'),
+        $repeated[] = $mform->createElement('group', 'autofirerow1', '',
                                             $autofirerow1, null, false);
 
         $autofirerow2 = array();
-        $autofirerow2[] = $mform->createElement('select', 'checkpowerof10', '', $checkpowerof10options);
+        $autofirerow2[] = $mform->createElement('select', 'checkpowerof10',
+                                            get_string('checkpowerof10', 'qtype_varnumericset'), $checkpowerof10options);
         $autofirerow2[] = $mform->createElement('selectyesno', 'checkrounding',
                                                  get_string('checkrounding', 'qtype_varnumericset'));
-        $repeated[] = $mform->createElement('group', 'autofirerow2', get_string('checkpowerof10', 'qtype_varnumericset'),
+        $repeated[] = $mform->createElement('group', 'autofirerow2', '',
                                             $autofirerow2, null, false);
 
-        $repeated[] = $mform->createElement('select', 'syserrorpenalty',
+        $autofirerow3 = array();
+        $autofirerow3[] = $mform->createElement('select', 'syserrorpenalty',
                                                  get_string('syserrorpenalty', 'qtype_varnumericset'), $gradeoptions);
+        $repeated[] = $mform->createElement('group', 'autofirerow3', '',
+                                            $autofirerow3, null, false);
 
         $repeatedoptions['answer']['type'] = PARAM_RAW;
         $repeatedoptions['fraction']['default'] = 0;

--- a/styles.css
+++ b/styles.css
@@ -45,7 +45,7 @@ body#page-question-type-varnumericset div[id^=fgroup_id_][id*=autofirerow2_] {
     border-bottom: 0;
 }
 /* Bottom */
-body#page-question-type-varnumericset div[id^=fitem_id_][id*=syserrorpenalty_] {
+body#page-question-type-varnumericset div[id^=fgroup_id_][id*=autofirerow3_] {
     background: #EEE;
     margin-bottom: 2em;
     margin-top: 0;
@@ -77,11 +77,14 @@ body#page-question-type-varnumericset div[id^=fitem_id_][id*=requirescinotation]
 body#page-question-type-varnumericset #fitem_id_answer_0 {
     margin-top: 1em;
 }
-body#page-question-type-varnumericset div[id^=fgroup_id_][id*=answeroptions_] label[for^='id_answer_'],
-body#page-question-type-varnumericset div[id^=fgroup_id_][id*=autofirerow1_] label[for^='id_checknumerical_'],
-body#page-question-type-varnumericset div[id^=fgroup_id_][id*=autofirerow2_] label[for^='id_checkpowerof10_'] {
+body#page-question-type-varnumericset div[id^=fgroup_id_][id*=answeroptions_] label[for^='id_answer_'] {
     position: absolute;
     left: -10000px;
     font-weight: normal;
     font-size: 1em;
+}
+body#page-question-type-varnumericset div[id^=fgroup_id_][id*=autofirerow1_] label[for^='id_checknumerical_'],
+body#page-question-type-varnumericset div[id^=fgroup_id_][id*=autofirerow2_] label[for^='id_checkpowerof10_'],
+body#page-question-type-varnumericset div[id^=fgroup_id_][id*=autofirerow3_] label[for^='id_syserrorpenalty_'] {
+    margin-left: 0;	
 }


### PR DESCRIPTION
Phil asked 

Within each Answer box I would suggest that the bottom three lines should be indented to line up under "Give feedback...".

This commit addresses this request. Leaving separate from main bug in case a different fix is required. Specifically had to group the field 'syserrorpenalty' into a new group 'autofirerow3' to align the labels properly. This may not be the best solution. 
