### PR TITLE
PHPUnit tests fixes

### DIFF
--- a/tests/question_test.php
+++ b/tests/question_test.php
@@ -46,12 +46,12 @@ class qtype_varnumericset_question_test extends advanced_testcase {
      */
     public function num_within_allowed_error_cases() {
         return [
-            ['1.23000000000001e4', 1.23e4, '', true],
-            ['1.23000000000002e4', 1.23e4, '', false],
-            ['-1.23000000000001e4', -1.23e4, '', true],
-            ['-1.23000000000002e4', -1.23e4, '', false],
-            ['-9.00000000000009e-4', -9e-4, '', true],
-            ['-9.00000000000010e-4', -9e-4, '', false],
+            ['1.23000000000001e4', 1.23e4, '0', true],
+            ['1.23000000000002e4', 1.23e4, '0', false],
+            ['-1.23000000000001e4', -1.23e4, '0', true],
+            ['-1.23000000000002e4', -1.23e4, '0', false],
+            ['-9.00000000000009e-4', -9e-4, '0', true],
+            ['-9.00000000000010e-4', -9e-4, '0', false],
             ['1.2301e4', 1.23e4, '1', true],
             ['1.23015e4', 1.23e4, '1', false],
             ['12299', 1.23e4, '1', true],
@@ -64,18 +64,18 @@ class qtype_varnumericset_question_test extends advanced_testcase {
             ['-1.2985', -1.23, '0.001', false],
             ['12301', 1.23e4, '1', true],
             ['12301.5', 1.23e4, '1', false],
-            ['-4', -4, '', true],
-            ['4', -4, '', false],
+            ['-4', -4, '0', true],
+            ['4', -4, '0', false],
             ['-4', -4, '0.0001', true],
             ['4', -4, '0.0001', false],
             [-4.20, -4.2, 0, true],
             [12, 12, 0, true],
-            ['9437183', 9437184, '', false],
-            ['9437184', 9437184, '', true],
-            ['9437185', 9437184, '', false],
-            ['75497471', 75497472, '', false],
-            ['75497472', 75497472, '', true],
-            ['75497473', 75497472, '', false],
+            ['9437183', 9437184, '0', false],
+            ['9437184', 9437184, '0', true],
+            ['9437185', 9437184, '0', false],
+            ['75497471', 75497472, '0', false],
+            ['75497472', 75497472, '0', true],
+            ['75497473', 75497472, '0', false],
         ];
     }
 
@@ -365,7 +365,7 @@ class qtype_varnumericset_question_test extends advanced_testcase {
                 '1',         // Fraction.
                 '<p>Your answer is correct.</p>', // Feedback.
                 FORMAT_HTML, // Feedbackformat.
-                '',          // Sigfigs.
+                '0',          // Sigfigs.
                 '',          // Error.
                 '0.1',       // Syserrorpenalty.
                 '0',         // Checknumerical.


### PR DESCRIPTION
Changed several empty strings (' ') to 0 ('0') to fix the following failing PHPUnit tests:

````
1) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #0 ('1.23000000000001e4', 12300.0, '', true)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:88
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

2) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #1 ('1.23000000000002e4', 12300.0, '', false)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:91
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

3) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #2 ('-1.23000000000001e4', -12300.0, '', true)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:88
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

4) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #3 ('-1.23000000000002e4', -12300.0, '', false)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:91
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

5) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #4 ('-9.00000000000009e-4', -0.0009, '', true)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:88
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

6) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #5 ('-9.00000000000010e-4', -0.0009, '', false)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:91
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

7) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #18 ('-4', -4, '', true)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:88
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

8) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #19 ('4', -4, '', false)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:91
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

9) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #24 ('9437183', 9437184, '', false)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:91
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

10) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #25 ('9437184', 9437184, '', true)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:88
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

11) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #26 ('9437185', 9437184, '', false)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:91
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

12) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #27 ('75497471', 75497472, '', false)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:91
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

13) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #28 ('75497472', 75497472, '', true)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:88
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

14) qtype_varnumericset_question_test::test_num_within_allowed_error with data set #29 ('75497473', 75497472, '', false)
TypeError: abs(): Argument #1 ($num) must be of type int|float, string given

/var/www/html/question/type/varnumericset/questionbase.php:313
/var/www/html/question/type/varnumericset/tests/question_test.php:91
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94

15) qtype_varnumericset_question_test::test_compare_num_as_string_with_answer_no_rounding
TypeError: Unsupported operand types: string - float

/var/www/html/question/type/varnumericset/questionbase.php:365
/var/www/html/question/type/varnumericset/questionbase.php:241
/var/www/html/question/type/varnumericset/tests/question_test.php:376
/var/www/html/lib/phpunit/classes/advanced_testcase.php:94
````

Moodle version 4.2
PHP version 8.0