### PR TITLE
Code cleanup: remove complexity, simplify strings.

### DIFF
--- a/calculatorbase.php
+++ b/calculatorbase.php
@@ -137,10 +137,10 @@ abstract class qtype_varnumeric_calculator_base {
         $fromformfield = '';
         do {
             $key = array_shift($keys);
-            if ($fromformfield == '') {
+            if ($fromformfield === '') {
                 $fromformfield = $key;
             } else {
-                $fromformfield .= '[' . $key . ']';
+                $fromformfield .= "[$key]";
             }
             if (isset($value[$key])) {
                 $value = $value[$key];
@@ -217,15 +217,15 @@ abstract class qtype_varnumeric_calculator_base {
                             = $this->calculate_calculated_variant_values($variantno);
             foreach ($this->answers as $answerno => $answer) {
                 foreach (['answer', 'error'] as $prop) {
-                    if ($prop == 'error' && $answer->{$prop} == '') {
+                    if ($prop === 'error' && $answer->{$prop} === '') {
                         continue; // No error messages for blank allowed error fields in answer.
                     }
                     if (self::is_assignment($answer->{$prop})) {
                         // This is an assignment not legal here.
-                        $this->errors[$prop . '[' . $answerno . ']'] =
+                        $this->errors["{$prop}[{$answerno}]"] =
                             get_string('expressionmustevaluatetoanumber', 'qtype_varnumericset');
                     } else {
-                        $this->evaluate($answer->{$prop}, $prop . '[' . $answerno . ']');
+                        $this->evaluate($answer->{$prop}, "{$prop}[{$answerno}]");
                     }
                 }
             }
@@ -280,11 +280,11 @@ abstract class qtype_varnumeric_calculator_base {
             if (!$recalculatecalculated || !self::is_assignment($variablenameorassignment)) {
                 $varname = self::var_in_assignment($variablenameorassignment);
                 $this->evaluate($varname.'='.$this->get_defined_variant($varno, $variantno),
-                        'variant' . $variantno . '[' . $varno . ']');
+                        "variant{$variantno}[{$varno}]");
             } else {
                 $varname = self::var_in_assignment($variablenameorassignment);
                 EvalMathFuncs::set_random_seed($this->randomseed.$variantno.$varname);
-                $this->evaluate($variablenameorassignment, 'varname[' . $varno . ']');
+                $this->evaluate($variablenameorassignment, "varname[$varno]");
             }
         }
     }
@@ -301,7 +301,7 @@ abstract class qtype_varnumeric_calculator_base {
             if (self::is_assignment($variablenameorassignment)) {
                 $varname = self::var_in_assignment($variablenameorassignment);
                 $calculatedvariants[$varno]
-                            = $this->evaluate($varname, 'variant' . $variantno . '[' . $varno . ']');
+                            = $this->evaluate($varname, "variant$variantno[$varno]");
             }
         }
         return $calculatedvariants;
@@ -329,7 +329,7 @@ abstract class qtype_varnumeric_calculator_base {
         $this->ev = new EvalMath(true, true);
         foreach ($this->variables as $varno => $variablenameorassignment) {
             $varname = self::var_in_assignment($variablenameorassignment);
-            $this->evaluate($varname . '=' . $step->get_qt_var('_var' . $varname));
+            $this->evaluate("{$varname}=" . $step->get_qt_var("_var{$varname}"));
         }
     }
 
@@ -348,8 +348,9 @@ abstract class qtype_varnumeric_calculator_base {
         }
 
         for ($variantno = 0; $variantno < $formdata['noofvariants']; $variantno++) {
-            if (isset($formdata['variant'.$variantno])) {
-                $variants = $formdata['variant'.$variantno];
+            $key = 'variant' . $variantno;
+            if (isset($formdata[$key])) {
+                $variants = $formdata[$key];
                 foreach ($variants as $varno => $value) {
                     if ($formdata['vartype'][$varno] == 1) {
                         if ($value !== '') {
@@ -361,7 +362,7 @@ abstract class qtype_varnumeric_calculator_base {
         }
 
         foreach ($formdata['answer'] as $answerno => $answer) {
-            if (!empty($answer) && '*' != $answer) {
+            if (!empty($answer) && '*' !== $answer) {
                 $this->add_answer($answerno, $answer, $formdata['error'][$answerno]);
             }
         }

--- a/edit_varnumericset_form_base.php
+++ b/edit_varnumericset_form_base.php
@@ -46,8 +46,10 @@ abstract class qtype_varnumeric_edit_form_base extends question_edit_form {
 
         $answersoption = '';
 
-        $typemenu = [0 => get_string('vartypecalculated', 'qtype_varnumericset'),
-                            1 => get_string('vartypepredefined', 'qtype_varnumericset')];
+        $typemenu = [
+            0 => get_string('vartypecalculated', 'qtype_varnumericset'),
+            1 => get_string('vartypepredefined', 'qtype_varnumericset')
+        ];
 
         $repeated = [];
         $repeatedoptions = [];
@@ -160,7 +162,7 @@ abstract class qtype_varnumeric_edit_form_base extends question_edit_form {
             $repeated[] = $mform->createElement('text', "variant$i",
                 get_string('variant', 'qtype_varnumericset', $i + 1), ['size' => 40]);
             $repeatedoptions["variant$i"]['disabledif'] = ['vartype', 'eq', 0];
-            if ($i == 0) {
+            if ($i === 0) {
                 $repeatedoptions["variant$i"]['helpbutton']
                     = ['variants', 'qtype_varnumericset'];
             }
@@ -193,8 +195,7 @@ abstract class qtype_varnumeric_edit_form_base extends question_edit_form {
          * Need an element with an id to work with. Hidden fields have no id and are inserted at
          * the start of the form.
          */
-        $repeated[] = $mform->createElement('text', "variant_last",
-                'last variant', '', ['class' => 'last']);
+        $repeated[] = $mform->createElement('text', "variant_last", 'last variant', '', ['class' => 'last']);
         $mform->setType('variant_last', PARAM_TEXT);
     }
 
@@ -340,7 +341,7 @@ abstract class qtype_varnumeric_edit_form_base extends question_edit_form {
                 if ($data['fraction'][$key] == 1) {
                     $maxgrade = true;
                 }
-                if ($trimmedanswer == '*') {
+                if ($trimmedanswer === '*') {
                     if ($data['error'][$key] !== '') {
                         $errors["answeroptions[$key]"] = get_string('notolerancehere', 'qtype_varnumericset');
                     }
@@ -397,7 +398,7 @@ abstract class qtype_varnumeric_edit_form_base extends question_edit_form {
                 }
             }
         }
-        if (empty($errors)) {
+        if (count($errors) === 0) {
             $calculator = new $calculatorname();
             // Don't need to bother setting the random seed here as the
             // results of the evaluation are not important, we are just seeing

--- a/number_interpreter.php
+++ b/number_interpreter.php
@@ -117,10 +117,11 @@ abstract class qtype_varnumericset_number_interpreter_part_using_preg_pattern ex
                 $this->postfix = '';
             }
             $this->extract_parts($matches);
+
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**
@@ -169,9 +170,9 @@ abstract class qtype_varnumericset_number_interpreter_part_using_preg_pattern ex
     protected function get_normalised_sign() {
         if ($this->sign === '-') {
             return '-';
-        } else {
-            return '';
         }
+
+        return '';
     }
 
     #[\Override]
@@ -424,9 +425,9 @@ class qtype_varnumericset_number_interpreter_number_with_optional_sci_notation e
             }
             $this->prefix = $num->get_prefix();
             return true;
-        } else {
-            return false;
         }
+
+        return false;
     }
 
     /**

--- a/questionbase.php
+++ b/questionbase.php
@@ -137,9 +137,9 @@ class qtype_varnumeric_question_base extends question_graded_automatically_with_
     protected function get_pre_post_validation_error($prefix, $postfix) {
         if (!empty($prefix) || !empty($postfix)) {
             return get_string('notvalidnumberprepostfound', 'qtype_varnumericset');
-        } else {
-            return '';
         }
+
+        return '';
     }
 
     #[\Override]
@@ -191,9 +191,9 @@ class qtype_varnumeric_question_base extends question_graded_automatically_with_
         if (!is_null($answer)) {
             return [$answer->fraction,
                     question_state::graded_state_for_fraction($answer->fraction)];
-        } else {
-            return [0, question_state::$gradedwrong];
         }
+
+        return [0, question_state::$gradedwrong];
     }
 
     #[\Override]
@@ -221,7 +221,7 @@ class qtype_varnumeric_question_base extends question_graded_automatically_with_
                     $this->round_to($evaluated, $answer->sigfigs, $this->requirescinotation);
             $calculatorname = $this->qtype->calculator_name();
             $answer->answer = $calculatorname::htmlize_exponent($answer->answer);
-            if ($answer->error != '') {
+            if ($answer->error !== '') {
                 $answer->error = $this->calculator->evaluate($answer->error);
                 $answer->answer =
                             get_string('correctansweriserror', 'qtype_varnumericset', $answer);
@@ -231,9 +231,9 @@ class qtype_varnumeric_question_base extends question_graded_automatically_with_
                             get_string('correctanswerissigfigs', 'qtype_varnumericset', $answer);
             }
             return $answer;
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**
@@ -248,6 +248,8 @@ class qtype_varnumeric_question_base extends question_graded_automatically_with_
                 return $answer;
             }
         }
+
+        return null;
     }
 
     /**
@@ -272,11 +274,11 @@ class qtype_varnumeric_question_base extends question_graded_automatically_with_
         }
         $answertoreturn->feedback .= $warning;
         $state = question_state::graded_state_for_fraction($answertoreturn->fraction);
-        if ($penalty == 1 && $feedback == '') {
+        if ($penalty === 1 && $feedback === '') {
             return null;
-        } else {
-            return $answertoreturn;
         }
+
+        return $answertoreturn;
     }
 
     /**
@@ -295,7 +297,7 @@ class qtype_varnumeric_question_base extends question_graded_automatically_with_
         // Evaluate the answer.
         $evaluated = $this->calculator->evaluate($answer->answer);
         $rounded = (float)self::round_to($evaluated, $answer->sigfigs, false);
-        if ($answer->error == '') {
+        if ($answer->error === '') {
             $allowederror = 0;
         } else {
             $allowederror = $this->calculator->evaluate($answer->error);
@@ -386,9 +388,9 @@ class qtype_varnumeric_question_base extends question_graded_automatically_with_
     protected function feedback_for_post_prefix_parts($prefix, $postfix) {
         if ($prefix . $postfix !== '') {
             return get_string('preandpostfixesignored', 'qtype_varnumericset');
-        } else {
-            return '';
         }
+
+        return '';
     }
 
     /**
@@ -435,11 +437,8 @@ class qtype_varnumeric_question_base extends question_graded_automatically_with_
      */
     public static function has_number_of_sig_figs($normalizedstring, $sigfigs) {
         $scinotation = self::is_sci_notation($normalizedstring);
-        if (self::round_to($normalizedstring, $sigfigs, $scinotation) === $normalizedstring) {
-            return true;
-        } else {
-            return false;
-        }
+
+        return self::round_to($normalizedstring, $sigfigs, $scinotation) === $normalizedstring;
     }
 
     /**
@@ -548,28 +547,24 @@ class qtype_varnumeric_question_base extends question_graded_automatically_with_
      * @return boolean
      */
     public static function is_sci_notation($normalizedstring) {
-        if (strpos($normalizedstring ?? '', 'e') !== false) {
-            return true;
-        } else {
-            return false;
-        }
+
+        return strpos($normalizedstring, 'e') !== false;
     }
 
     #[\Override]
     public function check_file_access($qa, $options, $component, $filearea, $args, $forcedownload) {
-        if ($component == 'question' && $filearea == 'answerfeedback') {
+        if ($component === 'question' && $filearea === 'answerfeedback') {
             $currentanswer = $qa->get_last_qt_var('answer');
             $answer = $qa->get_question()->get_matching_answer(['answer' => $currentanswer]);
             $answerid = reset($args); // The itemid is answer id.
+
             return $options->feedback && $answerid == $answer->id;
-
-        } else if ($component == 'question' && $filearea == 'hint') {
-            return $this->check_hint_file_access($qa, $options, $args);
-
-        } else {
-            return parent::check_file_access($qa, $options, $component, $filearea,
-                    $args, $forcedownload);
         }
+        if ($component === 'question' && $filearea === 'hint') {
+            return $this->check_hint_file_access($qa, $options, $args);
+        }
+
+        return parent::check_file_access($qa, $options, $component, $filearea, $args, $forcedownload);
     }
 
     #[\Override]
@@ -624,9 +619,9 @@ class qtype_varnumeric_question_base extends question_graded_automatically_with_
         $hint = parent::get_hint($hintnumber, $qa);
         if ($state != question_state::$gradedpartial || !$hint->clearwrong) {
             return $hint;
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     #[\Override]

--- a/questiontypebase.php
+++ b/questiontypebase.php
@@ -68,7 +68,8 @@ abstract class qtype_varnumeric_base extends question_type {
 
     #[\Override]
     public function extra_answer_fields() {
-        return [$this->db_table_prefix().'_answers',
+        return [
+            $this->db_table_prefix().'_answers',
             'sigfigs',
             'error',
             'syserrorpenalty',
@@ -298,8 +299,8 @@ abstract class qtype_varnumeric_base extends question_type {
                 'id '.$oldvariantsidsql,
                 $oldvariantsids);
         }
-        return $changed;
 
+        return $changed;
     }
 
     /**
@@ -379,9 +380,9 @@ abstract class qtype_varnumeric_base extends question_type {
         // recalculating variable values.
         if (!empty($fromform->recalculatenow)) {
             return false;
-        } else {
-            return true;
         }
+
+        return true;
     }
 
     #[\Override]


### PR DESCRIPTION
I'd like to support you modernizing the source code of this very plugin! These are not bug fixes, just code cleanups, like:

- simplify creating strings containing variables
- simplify if conditions with return so the else block is obsolete
- turn some comparisons `==`, `!=` into strict comparisons `===` and `!==`
- reformat some arrays
- change `if ( expression ) { return true; } else { return false; }` to `return expression;`
- add some empty lines before `return $var`

There may be more locations in code that would benefit from these changes...